### PR TITLE
docs: mark complyscribe as archived

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Please report unacceptable behavior to one of the Code of Conduct [Committee mem
 In addition to this repository, ComplyTime has several sub-projects:
 
 * **[complyctl](https://github.com/complytime/complyctl)**: A command-line tool for streamlining end-to-end compliance workflows on local systems.
-* **[complyscribe](https://github.com/complytime/complyscribe)**: A workflow automation tool for compliance content authoring.
+* **[complyscribe](https://github.com/complytime/complyscribe)** *(archived)*: A workflow automation tool for compliance content authoring.
 * **[complytime-collector-components](https://github.com/complytime/complytime-collector-components)** (ComplyBeacon): A policy-driven observability toolkit for compliance evidence collection, extending the OpenTelemetry standard.
 * **[complytime-policies](https://github.com/complytime/complytime-policies)**: Engineering policies expressed in [Gemara](https://github.com/ossf/gemara) for the ComplyTime project.
 * **[gemara-mcp-server](https://github.com/complytime/gemara-mcp-server)**: An MCP server for automating the authoring of GRC Risk Assessment documentation in Gemara.

--- a/SUBPROJECTS.md
+++ b/SUBPROJECTS.md
@@ -25,9 +25,9 @@ This document outlines the subprojects under the ComplyTime umbrella, their stat
 
 ### complyscribe
 
-**Description**: A workflow automation tool for compliance content authoring.
+**Description**: A workflow automation tool for compliance content authoring. Archived after complyctl was redesigned to use Gemara, removing the need for OSCAL as input.
 
-**Status**: 🟡 Incubating
+**Status**: ⚪ Archived
 **Repository**: [complytime/complyscribe](https://github.com/complytime/complyscribe)
 **Language**: Python | **License**: Apache-2.0
 


### PR DESCRIPTION
## Summary

Updates community documentation to reflect that complyscribe is being archived.

### Changes

- **SUBPROJECTS.md**: Changed complyscribe status from "Incubating" to "Archived" and updated description to note it has been superseded by complyctl with Gemara integration
- **CONTRIBUTING.md**: Marked complyscribe as archived in the related repositories list

### Context

ComplyScribe was built to transform compliance content between CaC/content and OSCAL formats, providing OSCAL content consumed by complyctl. However, complyctl has been redesigned to use Gemara as its core engine and no longer requires OSCAL as input, making complyscribe obsolete.