### PR TITLE
docs: require rebase instead of merge commits in PRs

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -139,6 +139,9 @@ incremented with repository-specific content.
 - **Atomic Changes**: PRs MUST address a single concern and be small enough for
   focused review. Large, multi-concern PRs SHOULD be split into separate
   submissions.
+- **No Merge Commits**: Pull request branches MUST NOT contain merge commits.
+  Contributors MUST rebase onto the target branch when necessary to keep history
+  linear.
 - **Review Requirement**: All PRs REQUIRE review from at least two Maintainers.
 - **CI/CD Gates**:
   - **Standard**: All PRs MUST generally pass automated checks (linting, testing,


### PR DESCRIPTION
## Summary

- Adds a **No Merge Commits** rule under §3 Contribution Workflow → Pull Requests in `STYLE_GUIDE.md`
- States that PR branches MUST NOT contain merge commits and MUST rebase onto the target branch when necessary

## Where this was added

Under **Pull Requests (PRs)**, next to Atomic Changes / Review Requirement — this is PR branch hygiene rather than a separate branching-strategy topic.

## Related Issues

_N/A_

## Review Hints

- Confirm the wording matches intended team practice (rebase required; merge commits disallowed on PR branches)

---

Generated with Cursor assistance